### PR TITLE
Ceil starlette

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "titiler.core>=0.13.0,<0.14",
+    "starlette>=0.27.0,<0.28",
     "starlette-cramjam>=0.3,<0.4",
     "pydantic_settings~=2.0",
 ]


### PR DESCRIPTION
## What I am changing

- In liu of updating the **titiler** dependency, ceil the **starlette** to get things working again.

## How I did it

- The "breaking" **starlette** change to how it handles templates was changed in v0.28, so this just keeps us below that.

As an aside, I used `uv pip install --exclude-newer 2023-08-03 -e . --force-reinstall` to install dependencies as they were the last time CI passed on this repo — a nice trick to get a working build that I could then use to isolate where the break was.

## How you can test it

- A **uvicorn** server (per the README) would error on start with the bad **starlette** — with this change, it doesn't error.
